### PR TITLE
Support windows paths

### DIFF
--- a/src/handlers/fileResolver.js
+++ b/src/handlers/fileResolver.js
@@ -3,7 +3,7 @@ const enhancedResolve = require("enhanced-resolve");
 const { defaultParsableExtensions } = require("../models/Parsables");
 
 function checkNodeModules(absPath) {
-  return /node_modules/.test(absPath) || absPath[0] !== "/";
+  return /node_modules/.test(absPath) || (absPath[0] !== "/" && absPath[1] !== ':');
 }
 
 // by default resolve Parsable files even without .ext in import


### PR DESCRIPTION
A line in `fileResolver`  will falsely identify Windows paths (e.g. C://src/....) as node modules, and will thus stop the walk. I'm not entirely certain under what circumstances this second clause is supposed to guard against, since `absPath` should always be an absolute path. If we're trying to check for non-absolute paths, `path.isAbsolute` might be a better fix for this.