### PR TITLE
Added "no-report-server" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@foundation-lib/deadfile",
+  "name": "deadfile",
   "version": "0.0.7",
   "description": "Simple util to find deadcode and unused files in any JavaScript project (ES5, ES6, React, Vue, ...)",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "deadfile",
+  "name": "@foundation-lib/deadfile",
   "version": "0.0.7",
   "description": "Simple util to find deadcode and unused files in any JavaScript project (ES5, ES6, React, Vue, ...)",
   "main": "src/index.js",

--- a/src/bin.js
+++ b/src/bin.js
@@ -15,6 +15,7 @@ simple:                $0 ./src/index.js
 multiple entry:        $0 ./src/index.js ./src/entry2.js
 with custom directory: $0 ./src/index.js --dir /path/to/other/folder
 with  exclude:         $0 ./src/index.js --exclude tests  utils/webpack
+without report server: $0 ./src/index.js --no-report-server utils/webpack
 `
   )
   .options(inputOptions);

--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -25,7 +25,14 @@ const options = {
     default: [],
     type: "array",
     demandOption: false
-  }
+  },
+  RS: {
+    alias: "report-server",
+    describe: "Enable/disable the HTML report server",
+    default: true,
+    type: "boolean",
+    demandOption: false
+  },
 };
 
 module.exports = options;

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,13 @@ const WriteReportFile = require("./cli/WriteReportFile");
 const ReportServer = require("./reportServer/server");
 class DeadFile {
   constructor(argv) {
-    const { _: entry, dir, exclude = [], output } = argv;
+    const { _: entry, dir, exclude = [], output, reportServer: shouldUseReportServer = true } = argv;
 
     this.baseDir = this.dirToAbs(dir); // if dir is not absolute find based on pwd
     this.entry = this.entryToAbs(entry, dir); // if the entry is not absolute find the absolute
     this.exclude = exclude; // excluded files/folders
     this.output = output;
+    this.shouldUseReportServer = shouldUseReportServer;
 
     this.allAssets = AllAssets(dir, { exclude }); // Array
 
@@ -81,7 +82,7 @@ class DeadFile {
   reporting(data) {
     Logger(data, this.baseDir);
     WriteReportFile(data, this.output);
-    ReportServer(data, this.baseDir);
+    if (this.shouldUseReportServer) ReportServer(data, this.baseDir);
   }
 }
 


### PR DESCRIPTION
I ran into an issue where I was trying to run your code in CI/CD, and it stalled just after starting the report server to show the report in the browser. This also happened locally, where it stalled for a while at this point sometimes, but not as bad as in CI/CD. I'm not in need of the HTML report, so this PR adds an option to disable it for a given invocation.